### PR TITLE
docs: fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class SearchInputAndResults extends React.Component {
     this.setState({ result });
   };
   
-  compponentWillUnmount() {
+  componentWillUnmount() {
     this.setState = () => {};
   }
 }


### PR DESCRIPTION
Nice library. Fix a small typo in docs which prevents users copy-pasting example and running it.